### PR TITLE
[feat]: FP 추론 요청 구조 및 점수 계산 로직 리팩토링

### DIFF
--- a/app/api/fp_infer.py
+++ b/app/api/fp_infer.py
@@ -1,9 +1,34 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException
+
+from app.models.request import FPInferRequest
+from app.models.response import FPInferResponse
 from app.models.schema import OCRText, FPResult
 from app.services.fp_inference_service import run_fp_inference
+from app.services.fp_scoring import calculate_fp_score
 
 router = APIRouter()
 
-@router.post("/fp-infer", response_model=list[FPResult])
-def fp_infer(payload: OCRText):
-    return run_fp_inference(payload.ocr_text.strip())
+@router.post("/fp-infer", response_model=FPInferResponse)
+async def fp_infer(payload: FPInferRequest):
+    try:
+        all_results = []
+
+        # 1. 각 OCR 문장별 LangChain 추론 수행
+        for item in payload.ocr_items:
+            if item.text.strip():
+                result = await run_fp_inference(item.text.strip())
+                all_results.extend(result)
+
+        # 2. FP 점수 계산
+        print("OCR 문장별 LangChain 추론 수행완료!")
+        print(all_results)
+        total_score, scored_functions = calculate_fp_score(all_results)
+
+        return {
+            "project_id": payload.project_id,
+            "functions": scored_functions,
+            "total_fp_score": total_score
+        }
+
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"FP 추론 실패: {str(e)}")

--- a/app/data/fp_weights.json
+++ b/app/data/fp_weights.json
@@ -1,0 +1,27 @@
+{
+  "EI": {
+    "SIMPLE": 3,
+    "MEDIUM": 4,
+    "COMPLEX": 6
+  },
+  "EO": {
+    "SIMPLE": 4,
+    "MEDIUM": 5,
+    "COMPLEX": 7
+  },
+  "EQ": {
+    "SIMPLE": 3,
+    "MEDIUM": 4,
+    "COMPLEX": 6
+  },
+  "ILF": {
+    "SIMPLE": 7,
+    "MEDIUM": 10,
+    "COMPLEX": 15
+  },
+  "EIF": {
+    "SIMPLE": 5,
+    "MEDIUM": 7,
+    "COMPLEX": 10
+  }
+}

--- a/app/models/request.py
+++ b/app/models/request.py
@@ -1,0 +1,12 @@
+# models/request.py
+
+from pydantic import BaseModel
+from typing import List, Optional
+
+class OCRItem(BaseModel):
+    description: Optional[str] = None  # 선택: "권한 제어 기능" 등
+    text: str         # 실제 기능 명세 텍스트
+
+class FPInferRequest(BaseModel):
+    project_id: int
+    ocr_items: List[OCRItem]

--- a/app/models/response.py
+++ b/app/models/response.py
@@ -1,0 +1,18 @@
+# models/response.py
+
+from pydantic import BaseModel
+from typing import List, Literal
+
+class FPFunctionScore(BaseModel):
+    function_name: str
+    description: str
+    fp_type: Literal["EI", "EO", "EQ", "ILF", "EIF"]
+    complexity: Literal["SIMPLE", "MEDIUM", "COMPLEX"]
+    estimated_ftr: int
+    estimated_det: int
+    score: int
+
+class FPInferResponse(BaseModel):
+    project_id: int
+    functions: List[FPFunctionScore]
+    total_fp_score: int

--- a/app/services/fp_inference_service.py
+++ b/app/services/fp_inference_service.py
@@ -3,7 +3,7 @@ from app.chains.chains import rag_chain, fallback_chain
 from app.utils.parser import extract_result_text, postprocess_llm_output
 from app.models.schema import FPResult
 
-def run_fp_inference(ocr_text: str) -> list[FPResult]:
+async def run_fp_inference(ocr_text: str) -> list[FPResult]:
     raw_output = None
     search_results = retriever.invoke(ocr_text)
     use_fallback = not search_results or len(search_results) == 0
@@ -37,4 +37,9 @@ def run_fp_inference(ocr_text: str) -> list[FPResult]:
             ))
         except Exception as e:
             print("항목 파싱 실패:", item, "사유:", e)
+
+    print("[최종 결과 FPResult 리스트]:")
+    for fp in result:
+        print(fp.model_dump())  # Pydantic v2 기준, v1이면 .dict()
+
     return result

--- a/app/services/fp_scoring.py
+++ b/app/services/fp_scoring.py
@@ -1,0 +1,74 @@
+from typing import List, Dict, Tuple, Union
+from pathlib import Path
+import json
+
+from app.models.schema import FPResult
+
+# FP 점수 룰 JSON 경로
+FP_WEIGHTS_PATH = Path(__file__).resolve().parent.parent / "data" / "fp_weights.json"
+
+# 룰 로딩
+try:
+    with open(FP_WEIGHTS_PATH, "r", encoding="utf-8") as f:
+        FP_WEIGHTS: Dict[str, Dict[str, int]] = json.load(f)
+except FileNotFoundError:
+    raise RuntimeError(f"[에러] FP 점수 룰 파일이 존재하지 않습니다: {FP_WEIGHTS_PATH}")
+except json.JSONDecodeError:
+    raise RuntimeError(f"[에러] FP 점수 룰 파일이 올바른 JSON 형식이 아닙니다: {FP_WEIGHTS_PATH}")
+
+
+def _to_dict(item: Union[FPResult, Dict]) -> Dict:
+    """FPResult 또는 dict를 dict로 변환"""
+    if isinstance(item, dict):
+        return item
+    if hasattr(item, "model_dump"):  # Pydantic v2
+        return item.model_dump()
+    elif hasattr(item, "dict"):  # Pydantic v1
+        return item.dict()
+    else:
+        raise ValueError(f"[에러] dict로 변환 불가한 타입: {type(item)}")
+
+
+def calculate_fp_score(functions: List[Union[FPResult, Dict]]) -> Tuple[int, List[Dict]]:
+    """
+    기능 리스트를 입력 받아 각 기능별 FP 점수 계산 및 총합 반환
+
+    :param functions: 기능 추론 결과 리스트 (function_name, fp_type, complexity 등 포함)
+    :return: (총점수, 기능별 점수 포함 리스트)
+    """
+
+    total_score = 0
+    scored_functions = []
+
+    for index, raw_func in enumerate(functions):
+        try:
+            func = _to_dict(raw_func)
+
+            fp_type = func.get("fp_type", "").strip().upper()
+            complexity = func.get("complexity", "").strip().upper()
+
+            if not fp_type or not complexity:
+                print(f"[경고] 인덱스 {index}: fp_type 또는 complexity 누락 → 무시됨 - {func}")
+                continue
+
+            score = FP_WEIGHTS.get(fp_type, {}).get(complexity, 0)
+
+            if score == 0:
+                print(f"[주의] 인덱스 {index}: 유효하지 않은 조합 (fp_type: {fp_type}, complexity: {complexity}) 또는 점수 없음")
+
+            print(f"[점수 계산] function: {func.get('function_name')} / fp_type: {fp_type} / complexity: {complexity} → score: {score}")
+
+            enriched_func = {
+                **func,
+                "score": score
+            }
+
+            total_score += score
+            scored_functions.append(enriched_func)
+
+        except Exception as e:
+            print(f"[에러] 인덱스 {index} 기능 점수 계산 실패: {e} → 원본: {raw_func}")
+            continue
+
+    print(f"[총 FP 점수]: {total_score}")
+    return total_score, scored_functions

--- a/tests/test_fp_infer.py
+++ b/tests/test_fp_infer.py
@@ -1,42 +1,40 @@
 import requests
 
-test_cases = [
+test_items = [
     {
-        "ocr_text": "사용자의 권한에 따라 접근 가능한 기능을 제어한다.",
-        "description": "권한 제어 기능"
+        "description": "권한 제어 기능",
+        "text": "사용자의 권한에 따라 접근 가능한 기능을 제어한다."
     },
     {
-        "ocr_text": "사용자는 자신의 비밀번호를 변경할 수 있어야 한다.",
-        "description": "비밀번호 변경 기능"
+        "description": "비밀번호 변경 기능",
+        "text": "사용자는 자신의 비밀번호를 변경할 수 있어야 한다."
     },
     {
-        "ocr_text": "관리자는 게시글을 작성하고 삭제할 수 있다.",
-        "description": "게시글 작성 및 삭제"
+        "description": "게시글 작성 및 삭제",
+        "text": "관리자는 게시글을 작성하고 삭제할 수 있다."
     },
     {
-        "ocr_text": "시스템은 외부 회계 시스템과 연동하여 정산 정보를 교환해야 한다.",
-        "description": "외부 시스템 연동"
+        "description": "외부 시스템 연동",
+        "text": "시스템은 외부 회계 시스템과 연동하여 정산 정보를 교환해야 한다."
     },
     {
-        "ocr_text": "사용자는 로그인 후 자신의 정보를 조회할 수 있어야 한다.",
-        "description": "정보 조회 기능"
+        "description": "정보 조회 기능",
+        "text": "사용자는 로그인 후 자신의 정보를 조회할 수 있어야 한다."
     }
 ]
 
-for idx, case in enumerate(test_cases, 1):
-    payload = {
-        "ocr_text": case["ocr_text"],
-        "request_id": f"test-{idx:03}"
-    }
+payload = {
+    "project_id": 999,
+    "ocr_items": test_items
+}
 
-    res = requests.post("http://localhost:8100/fp-infer", json=payload)
+res = requests.post("http://localhost:8100/fp-infer", json=payload)
 
-    print("=" * 80)
-    print(f"[Test-{idx:03}] {case['description']}")
-    print(f"입력: {payload['ocr_text']}")
-    if res.status_code == 200:
-        print("[Success] 응답 결과:")
-        print(res.json())
-    else:
-        print(f"[Failed] 상태 코드: {res.status_code}")
-        print(res.text)
+print("=" * 100)
+print(f"[TEST] Project ID: {payload['project_id']}")
+if res.status_code == 200:
+    print("[Success] 응답 결과:")
+    print(res.json())
+else:
+    print(f"[Failed] 상태 코드: {res.status_code}")
+    print(res.text)


### PR DESCRIPTION
### 주요 변경 내용

- `FPInferRequest` 및 `OCRItem` 기반 추론 요청 구조 도입
- LangChain RAG + fallback 기반 기능별 FP 추론 결과를 `FPResult` 구조로 통일
- `fp_scoring.py` 내 calculate_fp_score 함수 리팩토링:
  - Pydantic 모델 대응
  - fp_type/complexity 유효성 검사 추가
  - 각 기능별 점수 계산 및 total score 반환
- 응답 포맷을 FPInferResponse로 정리하여 API 응답 구조 개선

### 테스트 결과
- 유효한 OCR 텍스트 리스트 입력 시 FP 추론 및 점수 계산 정상 동작 확인
- 잘못된 조합이나 누락 필드에 대해 로깅 처리 완료
- 총점, 기능별 점수, 구조 모두 정확하게 반환됨

### 참고 사항
- 향후 FP 점수 기준에 따라 등급화(소규모/중간/대형 등) 기능 확장 가능
- fallback 프롬프트 품질 개선 및 테스트 케이스 추가 예정

Closes #4 

